### PR TITLE
Add a unique class to each tax-form.

### DIFF
--- a/includes/class-user-taxonomy.php
+++ b/includes/class-user-taxonomy.php
@@ -738,7 +738,7 @@ class WP_User_Taxonomy {
 			'hide_empty' => false
 		) ); ?>
 
-		<form method="post" class="user-tax-form">
+		<form method="post" class="user-tax-form user-tax-form-<?php echo esc_attr( $this->taxonomy ); ?>">
 			<fieldset class="alignleft">
 				<legend class="screen-reader-text"><?php esc_html_e( 'Update Groups', 'wp-user-groups' ); ?></legend>
 


### PR DESCRIPTION
Sometimes I use CSS as a quick workaround to conditionally show/hide some things in the WordPress admin. For this, I need a unique class or ID for every element.

This commit adds a unique class to the tax-form element, in order to target them individually.