### PR TITLE
Added filter 'wp_user_groups_taxonomy_objects'

### DIFF
--- a/wp-user-groups/includes/classes/class-user-taxonomy.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy.php
@@ -601,9 +601,10 @@ class WP_User_Taxonomy {
 	 * @since 0.1.0
 	 */
 	protected function register_user_taxonomy() {
+		$objects = apply_filters( 'wp_user_groups_taxonomy_objects', 'user', $this->taxonomy, $this->parse_options() );
 		register_taxonomy(
 			$this->taxonomy,
-			'user',
+			$objects,
 			$this->parse_options()
 		);
 	}


### PR DESCRIPTION
Added a filter to allow adding the taxonomy to multiple objects (custom post types) in addition to users.
This provides the ability to assign a user to a taxonomy and also assign the same taxonomy to a custom post type, thus providing the ability to link users and the custom post type.

Example of use:
function my_user_groups_taxonomy_objects( $objects, $taxonomy, $options ) {
	if ( 'user-type' === $taxonomy ) {
		//= create array of objects / custom post types that the taxonomy can be used with
		$objects = array( $objects, 'page' );
	}
	return $objects;
}
add_filter( 'wp_user_groups_taxonomy_objects', 'my_user_groups_taxonomy_objects', 10, 3 );