### PR TITLE
Split wp_set_terms_for_user for bulk/non-bulk contexts

### DIFF
--- a/wp-user-groups/includes/classes/class-user-taxonomy.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy.php
@@ -338,8 +338,21 @@ class WP_User_Taxonomy {
 			}
 		}
 
+		// Make sure the current user can edit the user and assign terms before proceeding.
+		if ( ! $this->can_assign( $user_id ) ) {
+			return false;
+		}
+
+		$terms = isset( $_POST[ $taxonomy ] )
+			? $_POST[ $taxonomy ]
+			: null;
+
+		if ( is_array( $terms ) ) {
+			$terms = array_map( 'sanitize_key', $terms );
+		}
+
 		// Set terms for user
-		wp_set_terms_for_user( $user_id, $this->taxonomy );
+		wp_set_terms_for_user( $user_id, $this->taxonomy, $terms );
 	}
 
 	/**

--- a/wp-user-groups/includes/classes/class-user-taxonomy.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy.php
@@ -338,18 +338,15 @@ class WP_User_Taxonomy {
 			}
 		}
 
-		// Make sure the current user can edit the user and assign terms before proceeding.
+		// Make sure the current user can edit the user and assign terms before proceeding
 		if ( ! $this->can_assign( $user_id ) ) {
 			return false;
 		}
 
+		// Get terms from the $_POST global if available
 		$terms = isset( $_POST[ $taxonomy ] )
 			? $_POST[ $taxonomy ]
 			: null;
-
-		if ( is_array( $terms ) ) {
-			$terms = array_map( 'sanitize_key', $terms );
-		}
 
 		// Set terms for user
 		wp_set_terms_for_user( $user_id, $this->taxonomy, $terms );

--- a/wp-user-groups/includes/functions/common.php
+++ b/wp-user-groups/includes/functions/common.php
@@ -58,7 +58,7 @@ function wp_set_terms_for_user( $user_id, $taxonomy, $terms = array() ) {
 	} else {
 
 		// Sets the terms for the user
-		wp_set_object_terms( $user_id, $_terms, $taxonomy, false );
+		wp_set_object_terms( $user_id, $terms, $taxonomy, false );
 	}
 
 	// Clean the cache

--- a/wp-user-groups/includes/functions/common.php
+++ b/wp-user-groups/includes/functions/common.php
@@ -42,28 +42,13 @@ function wp_get_terms_for_user( $user = false, $taxonomy = '' ) {
  *
  * @since 0.1.0
  *
- * @param  int      $user_id
- * @param  string   $taxonomy
- * @param  array    $terms
- * @param  boolean  $bulk
+ * @param  int     $user_id
+ * @param  string  $taxonomy
+ * @param  array   $terms
  *
- * @return boolean
+ * @return void
  */
-function wp_set_terms_for_user( $user_id, $taxonomy, $terms = array(), $bulk = false ) {
-
-	// Get the taxonomy
-	$tax = get_taxonomy( $taxonomy );
-
-	// Make sure the current user can edit the user and assign terms before proceeding.
-	if ( ! current_user_can( 'edit_user', $user_id ) || ! current_user_can( $tax->cap->assign_terms ) ) {
-		return false;
-	}
-
-	if ( empty( $terms ) && empty( $bulk ) ) {
-		$terms = isset( $_POST[ $taxonomy ] )
-			? $_POST[ $taxonomy ]
-			: null;
-	}
+function wp_set_terms_for_user( $user_id, $taxonomy, $terms = array() ) {
 
 	// Delete all user terms
 	if ( is_null( $terms ) || empty( $terms ) ) {
@@ -71,7 +56,6 @@ function wp_set_terms_for_user( $user_id, $taxonomy, $terms = array(), $bulk = f
 
 	// Set the terms
 	} else {
-		$_terms = array_map( 'sanitize_key', $terms );
 
 		// Sets the terms for the user
 		wp_set_object_terms( $user_id, $_terms, $taxonomy, false );


### PR DESCRIPTION
Fixes #19 and #20 

This PR splits `wp_set_terms_for_user` into two functions:

+ `wp_set_terms_for_user` contains the basic functionality, interacting with `wp_*_object_terms` and the term cache
+ `wp_bulk_set_terms_for_user` wraps around `wp_set_terms_for_user`, with some extra help for handling admin editing contexts (bulk edit and on the user edit screen), such as capability checking, sanitizing keys, and pulling values from the `$_POST` global

`wp_set_terms_for_user` still supports the `bulk` parameter for backwards compatibility, although I did replace those with `wp_bulk_set_terms_for_user` in the plugin where appropriate.