### PR TITLE
Allow admins to manage managed taxonomies

### DIFF
--- a/wp-user-groups/includes/classes/class-user-taxonomy.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy.php
@@ -831,7 +831,11 @@ class WP_User_Taxonomy {
 	 * @return bool
 	 */
 	public function is_managed() {
-		return ! empty( $this->args['managed'] );
+		if ( current_user_can('administrator') ) {
+			return false;
+		} else {
+			return ! empty( $this->args['managed'] );
+		}
 	}
 
 	/**

--- a/wp-user-groups/includes/functions/taxonomies.php
+++ b/wp-user-groups/includes/functions/taxonomies.php
@@ -21,7 +21,8 @@ defined( 'ABSPATH' ) || exit;
 function wp_register_default_user_group_taxonomy() {
 	new WP_User_Taxonomy( 'user-group', 'users/group', array(
 		'singular' => __( 'Group',  'wp-user-groups' ),
-		'plural'   => __( 'Groups', 'wp-user-groups' )
+		'plural'   => __( 'Groups', 'wp-user-groups' ),
+		'managed'  => false
 	) );
 }
 
@@ -37,6 +38,7 @@ function wp_register_default_user_group_taxonomy() {
 function wp_register_default_user_type_taxonomy() {
 	new WP_User_Taxonomy( 'user-type',  'users/type', array(
 		'singular' => __( 'Type',  'wp-user-groups' ),
-		'plural'   => __( 'Types', 'wp-user-groups' )
+		'plural'   => __( 'Types', 'wp-user-groups' ),
+		'managed'  => false
 	) );
 }


### PR DESCRIPTION
Update public function is_managed() so that administrators can manage groups and types directly from user profiles.

Stubbed our managed argument within user taxonomy definitions.