### PR TITLE
Fix compatibility with WP User Profiles

### DIFF
--- a/wp-user-groups/includes/functions/admin.php
+++ b/wp-user-groups/includes/functions/admin.php
@@ -41,6 +41,7 @@ function wp_user_groups_add_profile_section( $sections = array() ) {
 		'name'  => esc_html__( 'Groups', 'wp-user-activity' ),
 		'cap'   => 'edit_profile',
 		'icon'  => 'dashicons-groups',
+		'parent' => '',
 		'order' => 90
 	);
 


### PR DESCRIPTION
Fixes #26 

The problem is that WP User Profiles uses a `parent` argument that WP User Groups doesn't specify. This fixes that and enables the `Groups` tab to show up again.

Tested and working as expected both on a regular user editing screen and on the `wp-admin/network/user` screen.