### PR TITLE
Keep label properties public and drop AllowDynamicProperties

### DIFF
--- a/wp-user-groups/includes/classes/class-user-taxonomy.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy.php
@@ -15,7 +15,6 @@ if ( ! class_exists( 'WP_User_Taxonomy' ) ) :
  *
  * @since 0.1.0
  */
-#[AllowDynamicProperties]
 class WP_User_Taxonomy {
 
 	/**
@@ -75,7 +74,7 @@ class WP_User_Taxonomy {
 	 *
 	 * @var string
 	 */
-	protected $tax_singular = '';
+	public $tax_singular = '';
 
 	/**
 	 * Plural label
@@ -84,7 +83,7 @@ class WP_User_Taxonomy {
 	 *
 	 * @var string
 	 */
-	protected $tax_plural = '';
+	public $tax_plural = '';
 
 	/**
 	 * Lowercase singular label
@@ -93,7 +92,7 @@ class WP_User_Taxonomy {
 	 *
 	 * @var string
 	 */
-	protected $tax_singular_low = '';
+	public $tax_singular_low = '';
 
 	/**
 	 * Lowercase plural label
@@ -102,7 +101,7 @@ class WP_User_Taxonomy {
 	 *
 	 * @var string
 	 */
-	protected $tax_plural_low = '';
+	public $tax_plural_low = '';
 
 	/**
 	 * Main constructor


### PR DESCRIPTION
Fixes the backward compatibility concern raised in #36, on top of the work merged in #35.

## Why

#35 resolved the PHP 8.2 deprecation notices from #32 by declaring the four label helper properties. That part is right and this PR keeps it. The one change is visibility.

Until #35 these were dynamic properties, and dynamic properties are implicitly **public**, so any code outside the class could read them. Declaring them `protected` turns that read into a fatal error.

That matters because the class hands itself to third parties in two places:

* `do_action( 'wp_user_taxonomy', $this )` (line 147)
* `apply_filters( 'wp_user_groups_row_actions', $actions, $tax, $term, $this )` (line 634)

Reading `$tax->tax_singular` from either is a reasonable thing for an integrator to do, and it works in every released version today.

Declaring the properties `public` removes the deprecation notices just as completely, with no behavior change for anyone.

This also drops `#[AllowDynamicProperties]`. Now that the properties are declared, the attribute has no effect on them. The only thing it still does is silently permit *undeclared* properties, which is the exact problem #32 was about. It was removed in d2d34b6 and re-added in e5f1f89 as a defensive measure, but with the declarations in place it mainly hides future typos such as `$this->tax_sngular = ...`.

## Testing

Tested on a live WordPress 6.x install running PHP 8.4, with a listener on `wp_user_taxonomy` that does nothing but read `$tax->tax_singular`:

| Version | Deprecation notices | Third party read |
| --- | --- | --- |
| 2.5.0 (what WordPress.org serves) | 4 | `'Group'` |
| `master` as merged in #35 | 0 | `Error: Cannot access protected property` |
| This PR | 0 | `'Group'` |

Also diffed every generated label and taxonomy argument before and after. All 37 values are byte identical to 2.5.0, so this is not a behavior change:

```
original lines: 37 | patched lines: 37
=== DIFF (empty means identical) ===
IDENTICAL - no regression
```

## Note for whenever you cut the release

Not touching version metadata here since that is your call, but flagging it while it is in view: `wp-user-groups.php` still reads `Version: 2.5.0` while `readme.txt` has `Stable tag: 2.5.1`, and WordPress.org is currently serving 2.5.0. You will probably want to set both when this ships. More detail in #36.
