### PR TITLE
Users: Use a list table for taxonomy relationships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,69 @@ jobs:
     uses: stuttter/.github/.github/workflows/wordpress-plugin-ci.yml@main
     with:
       php-versions: '["7.2", "7.4", "8.0", "8.2", "8.4"]'
+
+  integration:
+    name: WordPress ${{ matrix.wordpress }} / PHP ${{ matrix.php }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - wordpress: '5.2'
+            php: '7.4'
+          - wordpress: '7.1'
+            php: '8.4'
+    services:
+      mysql:
+        image: mysql:8.4.6@sha256:869218921e61d6c3c89820955d63cca42971f0e3e6c1e2792247bbd944ebc6e9
+        env:
+          MYSQL_DATABASE: wordpress_tests
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=root"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+    steps:
+      - name: Check out plugin
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up PHP and WP-CLI
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: wp-cli:2.12.0
+
+      - name: Install WordPress
+        env:
+          WP_VERSION: ${{ matrix.wordpress }}
+        shell: bash
+        run: |
+          wordpress_root="${RUNNER_TEMP}/wordpress"
+          wp core download --version="${WP_VERSION}" --path="${wordpress_root}"
+          wp config create \
+            --path="${wordpress_root}" \
+            --dbname=wordpress_tests \
+            --dbuser=wordpress \
+            --dbpass=wordpress \
+            --dbhost=127.0.0.1:3306 \
+            --skip-check
+          wp core install \
+            --path="${wordpress_root}" \
+            --url=https://example.test \
+            --title='WP User Groups tests' \
+            --admin_user=admin \
+            --admin_password=password \
+            --admin_email=admin@example.test \
+            --skip-email
+          ln -s "${GITHUB_WORKSPACE}" "${wordpress_root}/wp-content/plugins/wp-user-groups"
+          wp plugin activate wp-user-groups --path="${wordpress_root}"
+          wp eval-file "${GITHUB_WORKSPACE}/tests/integration/ListTableSmoke.php" --path="${wordpress_root}"

--- a/tests/UserTaxonomyTest.php
+++ b/tests/UserTaxonomyTest.php
@@ -61,4 +61,47 @@ final class UserTaxonomyTest extends TestCase {
 		$this->assertStringContainsString( 'name="wp_user_taxonomy_user-group"', $html );
 		$this->assertStringContainsString( '>Editors<', $html );
 	}
+
+	public function test_table_uses_taxonomy_column_filters(): void {
+		$GLOBALS['wpug_test']['returns']['current_user_can']  = false;
+		$GLOBALS['wpug_test']['returns']['is_object_in_term'] = false;
+		$GLOBALS['wpug_test']['callbacks']['apply_filters:manage_edit-user-group_columns'] = static function ( $columns ) {
+			$columns['favorite_color'] = 'Favorite color';
+			return $columns;
+		};
+		$GLOBALS['wpug_test']['callbacks']['apply_filters:manage_user-group_custom_column'] = static function ( $display, $column_name, $term_id ) {
+			return 'favorite_color' === $column_name ? "Color for {$term_id}" : $display;
+		};
+		$term = (object) array( 'term_id' => 8, 'slug' => 'editors', 'name' => 'Editors', 'description' => '', 'count' => 3 );
+		$tax  = (object) array( 'name' => 'user-group', 'labels' => (object) array( 'not_found' => 'No groups found' ) );
+
+		$html = $this->taxonomy()->render_table( (object) array( 'ID' => 7 ), $tax, array( $term ) );
+
+		$this->assertStringContainsString( '>Favorite color<', $html );
+		$this->assertStringContainsString( '>Color for 8<', $html );
+	}
+
+	public function test_exclusive_table_uses_radios_without_select_all(): void {
+		$GLOBALS['wpug_test']['returns']['current_user_can']  = false;
+		$GLOBALS['wpug_test']['returns']['is_object_in_term'] = false;
+		$term = (object) array( 'term_id' => 8, 'slug' => 'editors', 'name' => 'Editors', 'description' => '', 'count' => 3 );
+		$tax  = (object) array( 'name' => 'user-group', 'labels' => (object) array( 'not_found' => 'No groups found' ) );
+
+		$html = $this->taxonomy( array( 'exclusive' => true ) )->render_table( (object) array( 'ID' => 7 ), $tax, array( $term ) );
+
+		$this->assertStringContainsString( 'type="radio"', $html );
+		$this->assertStringNotContainsString( 'cb-select-all-', $html );
+	}
+
+	public function test_managed_table_has_no_relationship_inputs_for_non_administrators(): void {
+		$GLOBALS['wpug_test']['returns']['current_user_can']  = false;
+		$GLOBALS['wpug_test']['returns']['is_object_in_term'] = true;
+		$term = (object) array( 'term_id' => 8, 'slug' => 'editors', 'name' => 'Editors', 'description' => '', 'count' => 3 );
+		$tax  = (object) array( 'name' => 'user-group', 'labels' => (object) array( 'not_found' => 'No groups found' ) );
+
+		$html = $this->taxonomy( array( 'managed' => true ) )->render_table( (object) array( 'ID' => 7 ), $tax, array( $term ) );
+
+		$this->assertStringNotContainsString( 'name="user-group[]"', $html );
+		$this->assertStringContainsString( 'name="wp_user_taxonomy_user-group"', $html );
+	}
 }

--- a/tests/UserTaxonomyTest.php
+++ b/tests/UserTaxonomyTest.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-final class TestableUserTaxonomy extends WP_User_Taxonomy {
+class TestableUserTaxonomy extends WP_User_Taxonomy {
 	public function render_table( $user, $taxonomy, $terms ): string {
 		ob_start();
 		$this->table_contents( $user, $taxonomy, $terms );
 		return (string) ob_get_clean();
+	}
+}
+
+final class CustomRowActionsUserTaxonomy extends TestableUserTaxonomy {
+	protected function row_actions( $tax = array(), $term = false ) {
+		return 'Custom row action';
 	}
 }
 
@@ -60,6 +66,22 @@ final class UserTaxonomyTest extends TestCase {
 		$this->assertStringContainsString( 'checked="checked"', $html );
 		$this->assertStringContainsString( 'name="wp_user_taxonomy_user-group"', $html );
 		$this->assertStringContainsString( '>Editors<', $html );
+		$this->assertCount( 1, $GLOBALS['wpug_test']['calls']['is_object_in_term'] );
+	}
+
+	public function test_table_preserves_subclass_row_actions_extension_point(): void {
+		$GLOBALS['wpug_test']['returns']['current_user_can']  = false;
+		$GLOBALS['wpug_test']['returns']['is_object_in_term'] = false;
+		$term = (object) array( 'term_id' => 8, 'slug' => 'editors', 'name' => 'Editors', 'description' => '', 'count' => 3 );
+		$tax  = (object) array( 'name' => 'user-group', 'labels' => (object) array( 'not_found' => 'No groups found' ) );
+		$reflection = new ReflectionClass( CustomRowActionsUserTaxonomy::class );
+		$taxonomy   = $reflection->newInstanceWithoutConstructor();
+		$taxonomy->taxonomy = 'user-group';
+		$taxonomy->args     = array();
+
+		$html = $taxonomy->render_table( (object) array( 'ID' => 7 ), $tax, array( $term ) );
+
+		$this->assertStringContainsString( 'Custom row action', $html );
 	}
 
 	public function test_table_uses_taxonomy_column_filters(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,7 +32,13 @@ function is_object_in_term( ...$arguments ) { return (bool) wpug_test_call( __FU
 function esc_html_e( $text ) { echo htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' ); }
 function esc_attr( $text ) { return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' ); }
 function esc_html( $text ) { return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' ); }
-function checked( $checked ) { if ($checked) { echo 'checked="checked"'; } }
+function checked( $checked, $current = true, $display = true ) {
+	$result = ( (string) $checked === (string) $current ) ? 'checked="checked"' : '';
+	if ( $display ) {
+		echo $result;
+	}
+	return $result;
+}
 function admin_url( $path ) { return 'https://example.test/wp-admin/' . ltrim( $path, '/' ); }
 function add_query_arg( $args, $url ) { return $url . '?' . http_build_query( $args ); }
 function esc_url( $url ) { return $url; }
@@ -40,6 +46,66 @@ function wp_nonce_field( $action, $name ) { echo '<input type="hidden" name="' .
 
 class WP_Error {}
 
+class WP_List_Table {
+	public $items = array();
+	protected $_args = array();
+	protected $_column_headers = array();
+
+	public function __construct( $args = array() ) {
+		$this->_args = $args;
+	}
+
+	protected function set_pagination_args( $args ) {}
+
+	protected function get_table_classes() {
+		return array( 'widefat', 'fixed', 'striped' );
+	}
+
+	protected function display_tablenav( $which ) {}
+
+	protected function single_row_columns( $item ) {
+		foreach ( $this->_column_headers[0] as $column_name => $label ) {
+			$method = 'column_' . $column_name;
+			$value  = method_exists( $this, $method )
+				? $this->$method( $item )
+				: $this->column_default( $item, $column_name );
+			$tag = ( 'cb' === $column_name ) ? 'th' : 'td';
+			echo '<' . $tag . ' class="column-' . esc_attr( $column_name ) . '">' . $value . '</' . $tag . '>';
+		}
+	}
+
+	protected function print_column_headers() {
+		static $select_all = 0;
+		++$select_all;
+		foreach ( $this->_column_headers[0] as $column_name => $label ) {
+			if ( 'cb' === $column_name ) {
+				echo '<td class="column-cb check-column"><input id="cb-select-all-' . $select_all . '" type="checkbox" /></td>';
+			} else {
+				echo '<th class="column-' . esc_attr( $column_name ) . '">' . $label . '</th>';
+			}
+		}
+	}
+
+	public function display() {
+		echo '<table class="wp-list-table ' . esc_attr( implode( ' ', $this->get_table_classes() ) ) . '"><thead><tr>';
+		$this->print_column_headers();
+		echo '</tr></thead><tbody>';
+		if ( empty( $this->items ) ) {
+			echo '<tr><td>';
+			$this->no_items();
+			echo '</td></tr>';
+		} else {
+			foreach ( $this->items as $item ) {
+				$this->single_row( $item );
+			}
+		}
+		echo '</tbody><tfoot><tr>';
+		$this->print_column_headers();
+		echo '</tr></tfoot></table>';
+	}
+}
+
 require_once dirname( __DIR__ ) . '/wp-user-groups/includes/functions/common.php';
 require_once dirname( __DIR__ ) . '/wp-user-groups/includes/functions/admin.php';
 require_once dirname( __DIR__ ) . '/wp-user-groups/includes/classes/class-user-taxonomy.php';
+require_once dirname( __DIR__ ) . '/wp-user-groups/includes/classes/class-user-taxonomy-list-table.php';

--- a/tests/integration/ListTableSmoke.php
+++ b/tests/integration/ListTableSmoke.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Real-WordPress smoke coverage for the user taxonomy list table.
+ */
+
+defined( 'ABSPATH' ) || exit( 1 );
+
+function wpug_smoke_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+if ( ! class_exists( 'WP_User_Taxonomy_List_Table' ) ) {
+	require_once WP_PLUGIN_DIR . '/wp-user-groups/wp-user-groups/includes/classes/class-user-taxonomy-list-table.php';
+}
+
+set_current_screen( 'user-edit' );
+wp_set_current_user( 1 );
+
+class WPUG_Smoke_User_Taxonomy extends WP_User_Taxonomy {
+	public function render_for_smoke_test( $user, $taxonomy, $terms ) {
+		ob_start();
+		$this->table_contents( $user, $taxonomy, $terms );
+		return ob_get_clean();
+	}
+}
+
+$controller = new WPUG_Smoke_User_Taxonomy(
+	'qa-user-group',
+	'users/qa-group',
+	array(
+		'singular' => 'QA Group',
+		'plural'   => 'QA Groups',
+		'managed'  => false,
+	)
+);
+
+$user_id = wp_create_user( 'list-table-user', wp_generate_password(), 'list-table@example.test' );
+$term    = wp_insert_term( 'Editors', 'qa-user-group', array( 'slug' => 'editors' ) );
+
+wpug_smoke_assert( ! is_wp_error( $user_id ), 'Could not create smoke-test user.' );
+wpug_smoke_assert( ! is_wp_error( $term ), 'Could not create smoke-test term.' );
+
+wp_set_object_terms( $user_id, array( (int) $term['term_id'] ), 'qa-user-group' );
+
+add_filter(
+	'manage_edit-qa-user-group_columns',
+	function ( $columns ) {
+		$columns['qa_marker'] = 'QA marker';
+		return $columns;
+	}
+);
+add_filter(
+	'manage_qa-user-group_custom_column',
+	function ( $display, $column_name, $term_id ) use ( $term ) {
+		if ( 'qa_marker' === $column_name ) {
+			return ( (int) $term['term_id'] === (int) $term_id ) ? 'custom-column-ok' : 'wrong-term';
+		}
+		return $display;
+	},
+	20,
+	3
+);
+
+$taxonomy = get_taxonomy( 'qa-user-group' );
+$terms    = get_terms(
+	array(
+		'taxonomy'   => 'qa-user-group',
+		'hide_empty' => false,
+	)
+);
+$html     = $controller->render_for_smoke_test( get_user_by( 'id', $user_id ), $taxonomy, $terms );
+
+wpug_smoke_assert( false !== strpos( $html, 'wp-list-table' ), 'List table markup is missing.' );
+wpug_smoke_assert( false !== strpos( $html, 'QA marker' ), 'Custom taxonomy column heading is missing.' );
+wpug_smoke_assert( false !== strpos( $html, 'custom-column-ok' ), 'Custom taxonomy column value is missing.' );
+wpug_smoke_assert( false !== strpos( $html, 'name="qa-user-group[]"' ), 'Relationship checkbox is missing.' );
+wpug_smoke_assert( false !== strpos( $html, 'wp_user_taxonomy_qa-user-group' ), 'Relationship nonce is missing.' );
+wpug_smoke_assert( (bool) preg_match( '/checked=(?:"checked"|\'checked\')/', $html ), 'Selected relationship is not checked.' );
+
+echo "WP User Groups list-table smoke test passed.\n";

--- a/wp-user-groups.php
+++ b/wp-user-groups.php
@@ -30,6 +30,12 @@ function _wp_user_groups() {
 
 	// Classes
 	require_once $plugin_path . 'includes/classes/class-user-taxonomy.php';
+	if ( is_admin() ) {
+		if ( ! class_exists( 'WP_List_Table' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+		}
+		require_once $plugin_path . 'includes/classes/class-user-taxonomy-list-table.php';
+	}
 
 	// Functions
 	require_once $plugin_path . 'includes/functions/admin.php';

--- a/wp-user-groups/assets/css/user-groups.css
+++ b/wp-user-groups/assets/css/user-groups.css
@@ -13,6 +13,12 @@ table.user-groups tfoot td.check-column,
 table.user-groups .inactive th.check-column{
 	padding-left: 6px;
 }
+table.user-groups .column-selection {
+	width: 2.2em;
+}
+table.user-groups tbody td.column-selection {
+	padding-left: 9px;
+}
 table.user-groups tbody th.check-column,
 table.user-groups tbody {
 	padding: 12px 0 0 2px;
@@ -83,6 +89,9 @@ table.user-groups tbody tr:last-of-type th {
 }
 
 table.user-groups .active th.check-column {
+	border-left: 4px solid #00a0d2;
+}
+table.user-groups .active td.column-selection {
 	border-left: 4px solid #00a0d2;
 }
 

--- a/wp-user-groups/includes/classes/class-user-taxonomy-list-table.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy-list-table.php
@@ -1,0 +1,280 @@
+<?php
+
+/**
+ * User taxonomy relationship list table.
+ *
+ * @package Plugins/Users/Groups/Classes/ListTable
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_User_Taxonomy_List_Table' ) ) :
+
+/**
+ * Displays one user taxonomy's terms on a user profile.
+ *
+ * @since 2.7.0
+ */
+class WP_User_Taxonomy_List_Table extends WP_List_Table {
+
+	/**
+	 * User taxonomy controller.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @var WP_User_Taxonomy
+	 */
+	protected $user_taxonomy;
+
+	/**
+	 * User whose relationships are being displayed.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * Registered taxonomy object.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @var WP_Taxonomy
+	 */
+	protected $taxonomy;
+
+	/**
+	 * Whether this taxonomy uses the checkbox selection column.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @var bool
+	 */
+	protected $has_bulk_selection = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_User_Taxonomy $user_taxonomy User taxonomy controller.
+	 * @param WP_User          $user          User being edited.
+	 * @param WP_Taxonomy      $taxonomy      Registered taxonomy object.
+	 * @param array            $terms         Terms to display.
+	 */
+	public function __construct( $user_taxonomy, $user, $taxonomy, $terms = array() ) {
+		$this->user_taxonomy    = $user_taxonomy;
+		$this->user             = $user;
+		$this->taxonomy         = $taxonomy;
+		$this->items            = is_array( $terms ) ? $terms : array();
+		$this->has_bulk_selection = ! $user_taxonomy->is_managed() && ! $user_taxonomy->is_exclusive();
+
+		parent::__construct( array(
+			'singular' => 'user-group',
+			'plural'   => 'user-groups',
+			'ajax'     => false,
+		) );
+	}
+
+	/**
+	 * Prepare the fixed set of terms and column metadata.
+	 *
+	 * @since 2.7.0
+	 */
+	public function prepare_items() {
+		$columns = $this->get_columns();
+		$primary = isset( $columns['name'] ) ? 'name' : key( $columns );
+
+		$this->_column_headers = array( $columns, array(), array(), $primary );
+		$this->set_pagination_args( array(
+			'total_items' => count( $this->items ),
+			'per_page'    => max( 1, count( $this->items ) ),
+			'total_pages' => 1,
+		) );
+	}
+
+	/**
+	 * Return columns, including taxonomy-specific custom columns.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		$selection_column = $this->has_bulk_selection ? 'cb' : 'selection';
+		$columns = array(
+			$selection_column => '',
+			'name'            => esc_html__( 'Name', 'wp-user-groups' ),
+			'description'     => esc_html__( 'Description', 'wp-user-groups' ),
+			'users'           => esc_html__( 'Users', 'wp-user-groups' ),
+		);
+
+		/**
+		 * Filters the columns displayed for this user taxonomy.
+		 *
+		 * This is the same dynamic hook used by the taxonomy terms list table.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param array $columns Column labels keyed by column name.
+		 */
+		return apply_filters( "manage_edit-{$this->taxonomy->name}_columns", $columns );
+	}
+
+	/**
+	 * Suppress empty navigation containers around this compact profile table.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param string $which Navigation position.
+	 */
+	protected function display_tablenav( $which ) {}
+
+	/**
+	 * Add the plugin's stable table class.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @return array
+	 */
+	protected function get_table_classes() {
+		return array( 'widefat', 'fixed', 'striped', 'user-groups' );
+	}
+
+	/**
+	 * Render one term row with its current relationship state.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term Term being displayed.
+	 */
+	public function single_row( $term ) {
+		$active = is_object_in_term( $this->user->ID, $this->taxonomy->name, $term->slug );
+		$class  = ( true === $active ) ? 'active' : 'inactive';
+
+		echo '<tr class="' . esc_attr( $class ) . '">';
+		$this->single_row_columns( $term );
+		echo '</tr>';
+	}
+
+	/**
+	 * Render a checkbox selection cell.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term Term being displayed.
+	 * @return string
+	 */
+	protected function column_cb( $term ) {
+		return $this->selection_input( $term, 'checkbox' );
+	}
+
+	/**
+	 * Render the non-bulk selection cell used by radios and managed tables.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term Term being displayed.
+	 * @return string
+	 */
+	protected function column_selection( $term ) {
+		if ( $this->user_taxonomy->is_managed() ) {
+			return '';
+		}
+
+		return $this->selection_input( $term, 'radio' );
+	}
+
+	/**
+	 * Build one relationship selection field.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term Term being displayed.
+	 * @param string  $type Input type.
+	 * @return string
+	 */
+	protected function selection_input( $term, $type ) {
+		$active = is_object_in_term( $this->user->ID, $this->taxonomy->name, $term->slug );
+		$id     = $this->taxonomy->name . '-' . $term->slug;
+
+		return sprintf(
+			'<input type="%1$s" name="%2$s[]" id="%3$s" value="%4$s" %5$s/><label class="screen-reader-text" for="%3$s">%6$s</label>',
+			esc_attr( $type ),
+			esc_attr( $this->taxonomy->name ),
+			esc_attr( $id ),
+			esc_attr( $term->slug ),
+			checked( $active, true, false ),
+			esc_html( $term->name )
+		);
+	}
+
+	/**
+	 * Render the primary term-name column.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term Term being displayed.
+	 * @return string
+	 */
+	protected function column_name( $term ) {
+		return '<strong>' . esc_html( $term->name ) . '</strong>'
+			. '<div class="row-actions">'
+			. $this->user_taxonomy->get_term_row_actions( $this->taxonomy, $term )
+			. '</div>';
+	}
+
+	/**
+	 * Render the description column.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term Term being displayed.
+	 * @return string
+	 */
+	protected function column_description( $term ) {
+		return ! empty( $term->description ) ? esc_html( $term->description ) : '&#8212;';
+	}
+
+	/**
+	 * Render native and custom taxonomy columns through the established hook.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term        Term being displayed.
+	 * @param string  $column_name Column name.
+	 * @return string
+	 */
+	protected function column_default( $term, $column_name ) {
+		/**
+		 * Filters a user taxonomy custom column's display value.
+		 *
+		 * This is the same dynamic hook used by the taxonomy terms list table.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param string $display     Existing display value.
+		 * @param string $column_name Column name.
+		 * @param int    $term_id     Term ID.
+		 */
+		return (string) apply_filters(
+			"manage_{$this->taxonomy->name}_custom_column",
+			'',
+			$column_name,
+			$term->term_id
+		);
+	}
+
+	/**
+	 * Display the taxonomy-specific empty state.
+	 *
+	 * @since 2.7.0
+	 */
+	public function no_items() {
+		echo esc_html( $this->taxonomy->labels->not_found );
+	}
+}
+
+endif;

--- a/wp-user-groups/includes/classes/class-user-taxonomy-list-table.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy-list-table.php
@@ -55,6 +55,15 @@ class WP_User_Taxonomy_List_Table extends WP_List_Table {
 	protected $has_bulk_selection = false;
 
 	/**
+	 * Cached relationship state keyed by term ID.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @var array
+	 */
+	protected $term_relationships = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 2.7.0
@@ -151,7 +160,7 @@ class WP_User_Taxonomy_List_Table extends WP_List_Table {
 	 * @param WP_Term $term Term being displayed.
 	 */
 	public function single_row( $term ) {
-		$active = is_object_in_term( $this->user->ID, $this->taxonomy->name, $term->slug );
+		$active = $this->is_term_active( $term );
 		$class  = ( true === $active ) ? 'active' : 'inactive';
 
 		echo '<tr class="' . esc_attr( $class ) . '">';
@@ -197,7 +206,7 @@ class WP_User_Taxonomy_List_Table extends WP_List_Table {
 	 * @return string
 	 */
 	protected function selection_input( $term, $type ) {
-		$active = is_object_in_term( $this->user->ID, $this->taxonomy->name, $term->slug );
+		$active = $this->is_term_active( $term );
 		$id     = $this->taxonomy->name . '-' . $term->slug;
 
 		return sprintf(
@@ -209,6 +218,24 @@ class WP_User_Taxonomy_List_Table extends WP_List_Table {
 			checked( $active, true, false ),
 			esc_html( $term->name )
 		);
+	}
+
+	/**
+	 * Return and cache whether the displayed user has a term relationship.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param WP_Term $term Term being displayed.
+	 * @return bool
+	 */
+	protected function is_term_active( $term ) {
+		$term_id = (int) $term->term_id;
+
+		if ( ! array_key_exists( $term_id, $this->term_relationships ) ) {
+			$this->term_relationships[ $term_id ] = is_object_in_term( $this->user->ID, $this->taxonomy->name, $term->slug );
+		}
+
+		return $this->term_relationships[ $term_id ];
 	}
 
 	/**

--- a/wp-user-groups/includes/classes/class-user-taxonomy.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy.php
@@ -540,19 +540,6 @@ class WP_User_Taxonomy {
 	 * @param object $term
 	 */
 	protected function row_actions( $tax = array(), $term = false ) {
-		return $this->get_term_row_actions( $tax, $term );
-	}
-
-	/**
-	 * Return row actions when editing a user.
-	 *
-	 * @since 2.7.0
-	 *
-	 * @param object $tax  Taxonomy object.
-	 * @param object $term Term object.
-	 * @return string
-	 */
-	public function get_term_row_actions( $tax = array(), $term = false ) {
 		$actions = array();
 
 		// List users in group
@@ -575,6 +562,22 @@ class WP_User_Taxonomy {
 		$actions = apply_filters( 'wp_user_groups_row_actions', $actions, $tax, $term, $this );
 
 		return implode( ' | ', $actions );
+	}
+
+	/**
+	 * Return row actions when editing a user.
+	 *
+	 * This public bridge preserves the protected row_actions() extension point
+	 * while allowing the separate list-table collaborator to render it.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param object $tax  Taxonomy object.
+	 * @param object $term Term object.
+	 * @return string
+	 */
+	public function get_term_row_actions( $tax = array(), $term = false ) {
+		return $this->row_actions( $tax, $term );
 	}
 
 	/**

--- a/wp-user-groups/includes/classes/class-user-taxonomy.php
+++ b/wp-user-groups/includes/classes/class-user-taxonomy.php
@@ -524,80 +524,9 @@ class WP_User_Taxonomy {
 	 * @since 0.1.6
 	 */
 	protected function table_contents( $user, $tax, $terms ) {
-		?>
-
-		<table class="wp-list-table widefat fixed striped user-groups">
-			<thead>
-				<tr>
-					<td id="cb" class="manage-column column-cb check-column">
-						<?php if ( ! $this->is_managed() && ! $this->is_exclusive() ) : ?>
-							<label class="screen-reader-text" for="cb-select-all-1"><?php esc_html_e( 'Select All', 'wp-user-groups' ); ?></label>
-							<input id="cb-select-all-1" type="checkbox">
-						<?php endif; ?>
-					</td>
-					<th scope="col" class="manage-column column-name column-primary"><?php esc_html_e( 'Name', 'wp-user-groups' ); ?></th>
-					<th scope="col" class="manage-column column-description"><?php esc_html_e( 'Description', 'wp-user-groups' ); ?></th>
-					<th scope="col" class="manage-column column-users"><?php esc_html_e( 'Users', 'wp-user-groups' ); ?></th>
-				</tr>
-			</thead>
-			<tbody>
-
-				<?php if ( ! empty( $terms ) ) :
-
-					foreach ( $terms as $term ) :
-						$active = is_object_in_term( $user->ID, $this->taxonomy, $term->slug ); ?>
-
-						<tr class="<?php echo ( true === $active ) ? 'active' : 'inactive'; ?>">
-							<th scope="row" class="check-column">
-								<?php if ( ! $this->is_managed() ) : ?>
-									<input type="<?php echo $this->is_exclusive() ? 'radio' : 'checkbox'; ?>" name="<?php echo esc_attr( $this->taxonomy ); ?>[]" id="<?php echo esc_attr( $this->taxonomy ); ?>-<?php echo esc_attr( $term->slug ); ?>" value="<?php echo esc_attr( $term->slug ); ?>" <?php checked( $active ); ?> />
-									<label for="<?php echo esc_attr( $this->taxonomy ); ?>-<?php echo esc_attr( $term->slug ); ?>"></label>
-								<?php endif; ?>
-							</th>
-							<td class="column-primary">
-								<strong><?php echo esc_html( $term->name ); ?></strong>
-								<div class="row-actions">
-									<?php echo $this->row_actions( $tax, $term ); ?>
-								</div>
-							</td>
-							<td class="column-description"><?php echo ! empty( $term->description ) ? esc_html( $term->description ) : '&#8212;'; ?></td>
-							<td class="column-users"><?php echo esc_html( $term->count ); ?></td>
-						</tr>
-
-					<?php
-
-					endforeach;
-
-				// If there are no user groups
-				else : ?>
-
-					<tr>
-						<td colspan="4">
-
-							<?php echo esc_html( $tax->labels->not_found ); ?>
-
-						</td>
-					</tr>
-
-				<?php endif; ?>
-
-			</tbody>
-			<tfoot>
-				<tr>
-					<td class="manage-column column-cb check-column">
-						<?php if ( ! $this->is_managed() && ! $this->is_exclusive() ) : ?>
-							<label class="screen-reader-text" for="cb-select-all-2"><?php esc_html_e( 'Select All', 'wp-user-groups' ); ?></label>
-							<input id="cb-select-all-2" type="checkbox">
-						<?php endif; ?>
-					</td>
-					<th scope="col" class="manage-column column-name column-primary"><?php esc_html_e( 'Name', 'wp-user-groups' ); ?></th>
-					<th scope="col" class="manage-column column-description"><?php esc_html_e( 'Description', 'wp-user-groups' ); ?></th>
-					<th scope="col" class="manage-column column-users"><?php esc_html_e( 'Users', 'wp-user-groups' ); ?></th>
-				</tr>
-			</tfoot>
-		</table>
-
-		<?php
+		$list_table = new WP_User_Taxonomy_List_Table( $this, $user, $tax, $terms );
+		$list_table->prepare_items();
+		$list_table->display();
 
 		// Nonce for table fields
 		$this->nonce_field();
@@ -611,6 +540,19 @@ class WP_User_Taxonomy {
 	 * @param object $term
 	 */
 	protected function row_actions( $tax = array(), $term = false ) {
+		return $this->get_term_row_actions( $tax, $term );
+	}
+
+	/**
+	 * Return row actions when editing a user.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param object $tax  Taxonomy object.
+	 * @param object $term Term object.
+	 * @return string
+	 */
+	public function get_term_row_actions( $tax = array(), $term = false ) {
 		$actions = array();
 
 		// List users in group


### PR DESCRIPTION
Fixes #22.

Replace the hard-coded user profile taxonomy table with a focused `WP_List_Table` collaborator.

Behavior and compatibility covered:

- routes columns through `manage_edit-{$taxonomy}_columns`
- routes custom values through `manage_{$taxonomy}_custom_column`
- preserves checkbox, exclusive-radio, managed/read-only, selection, nonce, row-action, and empty-state behavior
- avoids Select All controls for radio and managed tables
- lets Core generate unique Select All IDs when multiple taxonomy tables share a profile
- loads the private Core list-table dependency only for administration requests
- preserves PHP 7.2 and WordPress 5.2 syntax/contracts

Validation includes isolated characterization coverage plus real WordPress smoke jobs against the oldest supported WordPress line on PHP 7.4 and current WordPress on PHP 8.4. The test and automation foundation landed separately in #38.

## Independent review

Claude UltraReview identified two actionable findings. Commit `383fc0f` preserves subclass overrides of the historical protected `row_actions()` extension point and caches each row's relationship state so it is computed once. Regression coverage was added for both behaviors.
