### PR TITLE
Project: Require PHP 7.4

### DIFF
--- a/.github/plugin-standard.json
+++ b/.github/plugin-standard.json
@@ -3,11 +3,11 @@
   "slug": "wp-user-groups",
   "main_file": "wp-user-groups.php",
   "risk": "elevated",
-  "minimum_php": "7.2",
+  "minimum_php": "7.4",
   "minimum_wordpress": "5.2",
   "tested_wordpress": "7.1",
   "wordpress_org": true,
   "multisite": true,
   "release_branch": "master",
-  "php_matrix": ["7.2", "7.4", "8.0", "8.2", "8.4"]
+  "php_matrix": ["7.4", "8.0", "8.2", "8.4"]
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/stuttter/wp-user-groups",
   "type": "wordpress-plugin",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "composer/installers": "^1.12 || ^2.0"
   },
   "require-dev": {
@@ -30,7 +30,7 @@
       "composer/installers": true
     },
     "platform": {
-      "php": "7.2.0"
+      "php": "7.4.0"
     },
     "sort-packages": true
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be4f09b99fd764c98a06b6bd40a97185",
+    "content-hash": "fdf0e993b91f522cfec7a689cd1c5b48",
     "packages": [
         {
             "name": "composer/installers",
@@ -1621,11 +1621,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2"
+        "php": ">=7.4"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.2.0"
+        "php": "7.4.0"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 License:           GPLv2 or later
 Contributors:      johnjamesjacoby
 Tags:              user, profile, group, taxonomy, term
-Requires PHP:      7.2
+Requires PHP:      7.4
 Requires at least: 5.2
 Tested up to:      7.1
 Stable tag:        2.6.0

--- a/wp-user-groups.php
+++ b/wp-user-groups.php
@@ -10,7 +10,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       wp-user-groups
  * Requires at least: 5.2
- * Requires PHP:      7.2
+ * Requires PHP:      7.4
  * Tested up to:      7.1
  * Version:           2.6.0
  */


### PR DESCRIPTION
Raises WP User Groups’ published and Composer PHP requirement from 7.2 to 7.4, matching the minimum supported by WordPress 7.0.

No production behavior changes. Composer resolves the same package versions; only the root PHP requirement, platform override, lock metadata, plugin header, readme, and project manifest change.

Validation:

- PHP 7.4, 8.0, 8.2, and 8.4 syntax: pass
- PHPUnit on all four versions: 15 tests, 30 assertions
- composer validate --strict
- composer audit --locked: no advisories
- plugin metadata validation
- git diff --check
- signed commit verified locally

The protected managed workflow and AGENTS.md remain unchanged. The fleet synchronizer will remove the now-redundant PHP 7.2 syntax leg after this compatibility decision lands.